### PR TITLE
Migrate to GNOME 45-50

### DIFF
--- a/fildemGMenu@gonza.com/extension.js
+++ b/fildemGMenu@gonza.com/extension.js
@@ -1,19 +1,23 @@
 'use strict';
 
-const { loadInterfaceXML } = imports.misc.fileUtils;
+// import {loadInterfaceXML} from 'resource:///org/gnome/shell/misc/fileUtils.js';
 
-const { Clutter, Gio, GLib, GObject, Meta, St } = imports.gi;
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
+import GObject from 'gi://GObject?version=2.0';
+import Meta from 'gi://Meta';
+import St from 'gi://St?';
+import Shell from 'gi://Shell';
 
-const AppSystem  = imports.gi.Shell.AppSystem.get_default();
-const WinTracker = imports.gi.Shell.WindowTracker.get_default();
+import { Extension as GExtension } from "resource:///org/gnome/shell/extensions/extension.js";
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+const WinTracker = Shell.WindowTracker.get_default();
 
-const Settings = Me.imports.settings.FildemGlobalMenuSettings;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
-const WindowMenu = imports.ui.windowMenu;
+import { FildemGlobalMenuSettings as Settings } from './settings.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as WindowMenu from 'resource:///org/gnome/shell/ui/windowMenu.js';
 
 
 function log(msg) {
@@ -106,7 +110,7 @@ const WindowActions = class WindowActions {
 			if (rightMonitorIndex != -1)
 				this.actions.push('Move to Monitor Right');
 		}
-		
+
 		if (win.can_close())
 			this.actions.push('Close');
 
@@ -448,7 +452,7 @@ const MenuBar = class MenuBar {
 		this._restoreLabel();
 		this._hideMenu();
 		const overview = Main.overview.visibleTarget;
-		const focusApp = WinTracker.focus_app || Main.panel.statusArea.appMenu._targetApp;
+		const focusApp = WinTracker.focus_app || Main.panel.statusArea.appMenu?._targetApp;
 		if (focusApp) {
 			let windowData = {};
 			// TODO does the window matter?
@@ -680,15 +684,14 @@ class Extension {
 
 let extension;
 
-function init(metadata) {
-}
+export default class FildemMenuExtension extends GExtension {
+	enable() {
+		let settings = new Settings(this, this.metadata['settings-schema']);
+		extension = new Extension(settings);
+	}
 
-function enable() {
-	let settings = new Settings(Me.metadata['settings-schema']);
-	extension = new Extension(settings);
-}
-
-function disable() {
-	extension.destroy();
-	extension = null;
+	disable() {
+		extension.destroy();
+		extension = null;
+	}
 }

--- a/fildemGMenu@gonza.com/metadata.json
+++ b/fildemGMenu@gonza.com/metadata.json
@@ -3,7 +3,8 @@
   "description": "Global menu for Gnome",
   "settings-schema": "org.gnome.shell.extensions.fildem-global-menu",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "url": "https://github.com/gonzaarcr/Fildem",
   "uuid": "fildemGMenu@gonza.com"

--- a/fildemGMenu@gonza.com/metadata.json
+++ b/fildemGMenu@gonza.com/metadata.json
@@ -4,7 +4,8 @@
   "settings-schema": "org.gnome.shell.extensions.fildem-global-menu",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/gonzaarcr/Fildem",
   "uuid": "fildemGMenu@gonza.com"

--- a/fildemGMenu@gonza.com/metadata.json
+++ b/fildemGMenu@gonza.com/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/gonzaarcr/Fildem",
   "uuid": "fildemGMenu@gonza.com"

--- a/fildemGMenu@gonza.com/metadata.json
+++ b/fildemGMenu@gonza.com/metadata.json
@@ -6,7 +6,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/gonzaarcr/Fildem",
   "uuid": "fildemGMenu@gonza.com"

--- a/fildemGMenu@gonza.com/metadata.json
+++ b/fildemGMenu@gonza.com/metadata.json
@@ -3,11 +3,7 @@
   "description": "Global menu for Gnome",
   "settings-schema": "org.gnome.shell.extensions.fildem-global-menu",
   "shell-version": [
-    "3.36",
-    "3.38",
-    "40",
-    "41",
-    "42"
+    "45"
   ],
   "url": "https://github.com/gonzaarcr/Fildem",
   "uuid": "fildemGMenu@gonza.com"

--- a/fildemGMenu@gonza.com/prefs.js
+++ b/fildemGMenu@gonza.com/prefs.js
@@ -1,10 +1,11 @@
-const GObject = imports.gi.GObject;
-const Gio = imports.gi.Gio;
-const Gtk = imports.gi.Gtk;
-const Config = imports.misc.config;
+import GObject from 'gi://GObject?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
+import * as Config from 'resource:///org/gnome/Shell/Extensions/js/misc/config.js';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Settings = Me.imports.settings.FildemGlobalMenuSettings;
+// import {Extension as Me} from 'resource:///org/gnome/shell/extensions/extension.js';
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import {FildemGlobalMenuSettings as Settings} from './settings.js';
 
 const SHELL_VERSION = Config.PACKAGE_VERSION;
 
@@ -12,11 +13,11 @@ const SHELL_VERSION = Config.PACKAGE_VERSION;
 const PrefsWidget = GObject.registerClass(
 class PrefsWidget extends Gtk.Box {	
 
-	_init(settings, params) {
+	_init(conf, settings, params) {
 		super._init(params);
 
 		this._buildable = new Gtk.Builder();
-		this._buildable.add_from_file(Me.path + '/settings.ui');
+		this._buildable.add_from_file(conf.path + '/settings.ui');
 
 		let prefsWidget = this._getWidget('prefs_widget');
 		if (SHELL_VERSION < '40') {
@@ -87,9 +88,15 @@ function init() {
 
 }
 
-function buildPrefsWidget() {
-	let settings = new Settings(Me.metadata['settings-schema']);
-	let widget = new PrefsWidget(settings);
+export default class FildemMenuExtensionPrefs extends ExtensionPreferences {
+	getPreferencesWidget() {
+		return buildPrefsWidget(this);
+	}
+}
+
+function buildPrefsWidget(conf) {
+	let settings = new Settings(conf, conf.metadata['settings-schema']);
+	let widget = new PrefsWidget(conf, settings);
 	widget.show_all();
 
 	return widget;

--- a/fildemGMenu@gonza.com/settings.js
+++ b/fildemGMenu@gonza.com/settings.js
@@ -1,13 +1,15 @@
-const GObject = imports.gi.GObject;
-const Gio = imports.gi.Gio;
+import GObject from 'gi://GObject?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
 const GioSSS = Gio.SettingsSchemaSource;
-
-const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 var FildemGlobalMenuSettings = GObject.registerClass(
 class FildemGlobalMenuSettings extends Gio.Settings {
-	_init(schema) {
-		let schemaDir    = Me.dir.get_child('schemas');
+	constructor(conf, schema) {
+		super(schema, conf);
+	}
+
+	_init(schema, conf) {
+		let schemaDir    = conf.dir.get_child('schemas');
 		let schemaSource = null;
 
 		if (schemaDir.query_exists(null)) {
@@ -26,3 +28,5 @@ class FildemGlobalMenuSettings extends Gio.Settings {
 		super._init({ settings_schema: schemaObj });
 	}
 });
+
+export {FildemGlobalMenuSettings};


### PR DESCRIPTION
Migrated the extension to GNOME 45's ESM API, which also means older shell versions must be dropped.

fixes #175

How to install directly:
Suggested installation guide: https://www.linuxuprising.com/2021/02/how-to-install-fildem-global-menu-and.html

Before Step 2, you might need to install setuptools.
- Ubuntu: `sudo apt-get install python3-setuptools`
- Fedora: `sudo dnf install python-setuptools`

On Step 2, get release from this repo instead:
https://github.com/Weather-OS/Fildem-v2

After Step 2, execute:
```bash
git clone https://github.com/Sominemo/Fildem-Gnome-45.git
cd Fildem-Gnome-45
sudo cp -r fildemGMenu@gonza.com ~/.local/share/gnome-shell/extensions/fildemGMenu@gonza.com
```

> [!NOTE]  
> By default Fildem has “Show menu only when the mouse is over the panel” setting on, so it might appear like it’s not working. You need to hover over the title bar to see the menu, or you can disable this behavior in extension settings.

Re-login after installing